### PR TITLE
Adding Trace Linking Support for Stackify APM: transaction_id setting

### DIFF
--- a/lib/stackify/logger_client.rb
+++ b/lib/stackify/logger_client.rb
@@ -51,7 +51,7 @@ module Stackify
       current_level >= config_level
     end
 
-    def log_message_task level, msg, call_trace
+    def log_message_task level, msg, call_trace, id=nil
       Stackify::ScheduleTask.new ({limit: 1}) do
         if %w(error fatal).include?(level)
           ex = if ruby_exception?(msg) && msg.class != Class
@@ -63,16 +63,16 @@ module Stackify
             e
           end
           ex = StackifiedError.new(ex, binding())
-          Stackify.msgs_queue << Stackify::MsgObject.new(level, ex.message, caller[0], ex).to_h
+          Stackify.msgs_queue << Stackify::MsgObject.new(level, ex.message, caller[0], id, ex).to_h
         else
-          Stackify.msgs_queue << Stackify::MsgObject.new(level, msg, caller[0]).to_h
+          Stackify.msgs_queue << Stackify::MsgObject.new(level, msg, caller[0], id).to_h
         end
       end
     end
 
-    def log_exception_task level, ex
+    def log_exception_task level, ex, id=nil
       Stackify::ScheduleTask.new ({limit: 1}) do
-        Stackify.msgs_queue << Stackify::MsgObject.new(level, ex.message, caller[0], ex).to_h
+        Stackify.msgs_queue << Stackify::MsgObject.new(level, ex.message, caller[0], id, ex).to_h
       end
     end
 

--- a/lib/stackify/logger_client.rb
+++ b/lib/stackify/logger_client.rb
@@ -51,7 +51,7 @@ module Stackify
       current_level >= config_level
     end
 
-    def log_message_task level, msg, call_trace, id=nil
+    def log_message_task level, msg, call_trace, trans_id=nil, log_uuid=nil
       Stackify::ScheduleTask.new ({limit: 1}) do
         if %w(error fatal).include?(level)
           ex = if ruby_exception?(msg) && msg.class != Class
@@ -63,16 +63,16 @@ module Stackify
             e
           end
           ex = StackifiedError.new(ex, binding())
-          Stackify.msgs_queue << Stackify::MsgObject.new(level, ex.message, caller[0], id, ex).to_h
+          Stackify.msgs_queue << Stackify::MsgObject.new(level, ex.message, caller[0], trans_id, log_uuid, ex).to_h
         else
-          Stackify.msgs_queue << Stackify::MsgObject.new(level, msg, caller[0], id).to_h
+          Stackify.msgs_queue << Stackify::MsgObject.new(level, msg, caller[0], trans_id, log_uuid).to_h
         end
       end
     end
 
-    def log_exception_task level, ex, id=nil
+    def log_exception_task level, ex, trans_id=nil, log_uuid=nil
       Stackify::ScheduleTask.new ({limit: 1}) do
-        Stackify.msgs_queue << Stackify::MsgObject.new(level, ex.message, caller[0], id, ex).to_h
+        Stackify.msgs_queue << Stackify::MsgObject.new(level, ex.message, caller[0], trans_id, log_uuid, ex).to_h
       end
     end
 

--- a/lib/stackify/utils/msg_object.rb
+++ b/lib/stackify/utils/msg_object.rb
@@ -1,11 +1,13 @@
 module Stackify
   class MsgObject
-    def initialize level, msg, caller_str, id=nil, ex=nil
-      @level, @msg, @caller_str, @ex = level, msg, caller_str, ex, @id = id
+    def initialize level, msg, caller_str, trans_id=nil, log_uuid=nil, ex=nil
+      @level, @msg, @caller_str, @ex = level, msg, caller_str, ex, @trans_id = trans_id,
+      @log_uuid = log_uuid
     end
 
     def to_h
-      details = {
+      {
+        'id' => @log_uuid,
         'Msg' => @msg.to_s,
         'data' => nil,
         'Ex' => @ex.try(:to_h),
@@ -13,12 +15,10 @@ module Stackify
         #'Tags' => %w(ruby rails),
         'EpochMs' => Time.now.to_f * 1000,
         'Th' => Thread.current.object_id.to_s,
-        'TransID' => Stackify::EnvDetails.instance.request_details.try{ |d| d['uuid'] },
+        'TransID' => @trans_id,
         'SrcMethod' => Stackify::Backtrace.method_name(@caller_str),
         'SrcLine' => Stackify::Backtrace.line_number(@caller_str)
       }
-      details['Id'] = @id if @id
-      return details
     end
   end
 end

--- a/lib/stackify/utils/msg_object.rb
+++ b/lib/stackify/utils/msg_object.rb
@@ -1,11 +1,11 @@
 module Stackify
   class MsgObject
-    def initialize level, msg, caller_str, ex=nil
-      @level, @msg, @caller_str, @ex = level, msg, caller_str, ex
+    def initialize level, msg, caller_str, id=nil, ex=nil
+      @level, @msg, @caller_str, @ex = level, msg, caller_str, ex, @id = id
     end
 
     def to_h
-      {
+      details = {
         'Msg' => @msg.to_s,
         'data' => nil,
         'Ex' => @ex.try(:to_h),
@@ -17,6 +17,8 @@ module Stackify
         'SrcMethod' => Stackify::Backtrace.method_name(@caller_str),
         'SrcLine' => Stackify::Backtrace.line_number(@caller_str)
       }
+      details['Id'] = @id if @id
+      return details
     end
   end
 end


### PR DESCRIPTION
Adds the value of TransID and id which are being monkeypatched on the Stackify APM. Both are passed unto MsgObject to be sent as a log request to Stackify. 