### PR TITLE
Update the stackify/env_details.rb - set the value of Env from stackify setup

### DIFF
--- a/lib/stackify/env_details.rb
+++ b/lib/stackify/env_details.rb
@@ -35,7 +35,7 @@ module Stackify
         'AppLocation' => app_location,
         'AppName' => @app_name,
         'ConfiguredAppName' => @app_name,
-        'ConfiguredEnvironmentName' =>@info['Environment']
+        'ConfiguredEnvironmentName' => Stackify.configuration.env || @info['Environment']
       }
     end
 


### PR DESCRIPTION
If config.env was set in Stackify setup(stackify.rb) then we use that value instead from Rails environment.