### PR TITLE
Ruby API - Remove protobuf from ruby api - use jsoni

### DIFF
--- a/lib/stackify-api-ruby.rb
+++ b/lib/stackify-api-ruby.rb
@@ -2,8 +2,6 @@ require 'stackify/version'
 require 'stackify/utils/methods'
 require 'core_ext/core_ext' unless defined? Rails
 
-require 'google/protobuf'
-require 'proto/stackify-agent.rb'
 
 module Stackify
 
@@ -14,7 +12,6 @@ module Stackify
 
   autoload :Backtrace,            'stackify/utils/backtrace'
   autoload :MsgObject,            'stackify/utils/msg_object'
-  autoload :ProtobufLogObject,    'stackify/utils/protobuf_log_object'
   autoload :Configuration,        'stackify/utils/configuration'
   autoload :HttpClient,           'stackify/http_client'
   autoload :Authorizable,         'stackify/authorization/authorizable'

--- a/lib/stackify/agent_base_sender.rb
+++ b/lib/stackify/agent_base_sender.rb
@@ -1,5 +1,5 @@
 #
-# This class will handle the sending of protobuf message to agent
+# This class will handle the sending of log group message to agent
 #
 module Stackify
   class AgentBaseSender < Worker
@@ -23,13 +23,13 @@ module Stackify
     def send_logs_task attempts = nil, msgs
       properties[:attempts] = attempts if attempts
       Stackify::ScheduleTask.new properties do
-        data = create_log_group msgs
+        data = gather_and_pack_data(msgs).to_json
         send_request data
       end
     end
 
-    # create_log_group() This function will create a log group protobuf object
-    # @msgs {Object} Protobuf message
+    # create_log_group() This function will create a log group object
+    # @msgs {Object} log group message
     # return {Object} Return an object
     def create_log_group msgs
       # @details {Object} it will return the properties based in Stackify.setup() configuration
@@ -45,6 +45,24 @@ module Stackify
       log_group.logger = 'Ruby logger'
       log_group.platform = 'ruby'
       log_group
+    end
+
+    def gather_and_pack_data msgs
+      details = Stackify::EnvDetails.instance.auth_info
+      {
+        'CDID' => details['DeviceID'],
+        'CDAppID' => details['DeviceAppID'],
+        'Logger' => 'Rails logger',
+        'AppName' => details['AppName'],
+        'AppNameID' => details['AppNameID'],
+        'Env' => details['Env'],
+        'EnvID' => details['EnvID'],
+        'AppEnvID' => details['AppEnvID'],
+        'ServerName' => details['DeviceName'],
+        'Msgs' => msgs,
+        'AppLoc' => details['AppLocation'],
+        'Platform' => 'Ruby'
+      }
     end
 
     def send_request log_group

--- a/lib/stackify/agent_base_sender.rb
+++ b/lib/stackify/agent_base_sender.rb
@@ -28,25 +28,6 @@ module Stackify
       end
     end
 
-    # create_log_group() This function will create a log group object
-    # @msgs {Object} log group message
-    # return {Object} Return an object
-    def create_log_group msgs
-      # @details {Object} it will return the properties based in Stackify.setup() configuration
-      details = Stackify::Utils.get_app_settings
-      log_group = Stackify::LogGroup.new
-      msgs.each do |msg|
-        log_group.logs << msg
-      end
-      log_group.environment = details['env'].to_s
-      log_group.server_name = details['server_name'].to_s
-      log_group.application_name = details['app_name'].to_s
-      log_group.application_location = details['app_location'].to_s
-      log_group.logger = 'Ruby logger'
-      log_group.platform = 'ruby'
-      log_group
-    end
-
     def gather_and_pack_data msgs
       details = Stackify::EnvDetails.instance.auth_info
       {

--- a/lib/stackify/agent_client.rb
+++ b/lib/stackify/agent_client.rb
@@ -59,16 +59,16 @@ module Stackify
             e
           end
           ex = StackifiedError.new(ex, binding())
-          Stackify.msgs_queue << Stackify::ProtobufLogObject.new(level, ex.message, caller[0], trans_id, log_uuid, ex).to_obj
+          Stackify.msgs_queue << Stackify::MsgObject.new(level, ex.message, caller[0], trans_id, log_uuid, ex).to_h
         else
-          Stackify.msgs_queue << Stackify::ProtobufLogObject.new(level, msg, caller[0], trans_id, log_uuid).to_obj
+          Stackify.msgs_queue << Stackify::MsgObject.new(level, msg, caller[0], trans_id, log_uuid).to_h
         end
       end
     end
 
     def log_exception_task level, ex, trans_id=nil, log_uuid=nil
       Stackify::ScheduleTask.new ({limit: 1}) do
-        Stackify.msgs_queue << Stackify::ProtobufLogObject.new(level, ex.message, caller[0], trans_id, log_uuid, ex).to_obj
+        Stackify.msgs_queue << Stackify::MsgObject.new(level, ex.message, caller[0], trans_id, log_uuid, ex).to_h
       end
     end
 

--- a/lib/stackify/agent_client.rb
+++ b/lib/stackify/agent_client.rb
@@ -36,11 +36,11 @@ module Stackify
     end
 
     def has_error msg
-      !msg.error.nil?
+      !msg['Ex'].nil?
     end
 
     def get_epoch msg
-      msg.date_millis
+      msg['EpochMs']
     end
 
     def send_logs msgs, attempts = 3

--- a/lib/stackify/agent_http_sender.rb
+++ b/lib/stackify/agent_http_sender.rb
@@ -3,27 +3,25 @@ require 'faraday'
 require 'ostruct'
 
 #
-# This class will handle the sending of protobuf message to agent using http request
+# This class will handle the sending of log messages to agent using http request
 #
 module Stackify
   class AgentHTTPSender < AgentBaseSender
 
     HEADERS = {
-      'Content-Type' => 'application/x-protobuf'
+      'Content-Type' => 'application/json'
     }
 
     # send_request() This function will post an http request
-    # @msgs {Object} Protobuf message
+    # @msgs {Object} log group message
     # return {Object} Return an object {status, message}
     def send_request log_group
       begin
-        # Convert data into binary and send it to agent
-        message = Stackify::LogGroup.encode(log_group)
         conn = Faraday.new(proxy: Stackify.configuration.proxy, ssl: { verify: false })
         @response = conn.post do |req|
           req.url URI(Stackify.configuration.http_endpoint + Stackify.configuration.agent_log_url)
           req.headers = HEADERS
-          req.body = message
+          req.body = log_group
         end
         if @response.try(:status) == 200
           Stackify.internal_log :debug, "[AgentHTTPSender]: Successfully send message via http request."

--- a/lib/stackify/unix_socket_sender.rb
+++ b/lib/stackify/unix_socket_sender.rb
@@ -2,22 +2,20 @@ require 'net_http_unix'
 require 'ostruct'
 
 #
-# This class will handle the sending of protobuf message to unix domain socket
+# This class will handle the sending of log messages to unix domain socket
 #
 module Stackify
   class UnixSocketSender < AgentBaseSender
 
     # send_request() This function will send http request via unix domain socket
-    # @msgs {Object} Protobuf message
+    # @msgs {Object} log group message
     # return {Object} Return an object {status, message}
     def send_request log_group
       begin
-        # Convert data into binary and send it to unix domain socket
-        message = Stackify::LogGroup.encode(log_group)
         client = NetX::HTTPUnix.new('unix://' + Stackify.configuration.unix_socket_path)
         req = Net::HTTP::Post.new(Stackify.configuration.agent_log_url)
-        req.set_content_type('application/x-protobuf')
-        req.body = message
+        req.set_content_type('application/json')
+        req.body = log_group
         response = client.request(req)
         Stackify.internal_log :debug, "[UnixSocketSender] status_code = #{response.code}"
         if response.code.to_i == 200

--- a/stackify-api-ruby.gemspec
+++ b/stackify-api-ruby.gemspec
@@ -22,6 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake', '~> 0'
   spec.add_runtime_dependency 'faraday', '~> 0.8'
-  spec.add_runtime_dependency 'google-protobuf', '~> 3.0'
   spec.add_runtime_dependency 'net_http_unix', '~> 0.2'
 end


### PR DESCRIPTION
Changes:
- remove protobuf
- use json instead